### PR TITLE
add a window to configure some of the Plot2d widget options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,23 @@
 # vizkit
-An infrastructure for data display using qt ruby.
+
+A visualization toolkit for Rock using Qt
+
+Vizkit binds C++ and Ruby-based Qt widgets with Rock components and/or data
+streams (e.g. logs). The package provides integration for Rock's base widget
+collection [gui/rock_widget_collection](https://github.com/rock-core/gui-rock_widget_collection),
+and provides as well some widgets of its own - among which the task inspector widget.
 
 * http://rock-robotics.org
 
-# DESCRIPTION
+## Testing
 
-Provides a Qt ruby based framework for visualisation of rock data items.
-Visualisation plugins for specific data items are within the respective packages.
+Individual widgets may provide interactive tests. They are present in
+test/widgets/ and can be executed with
+
+~~~
+ruby test/widgets/test_plot2d.rb
+~~~
+
+During testing, a widget with Yes and No buttons will appear, which will
+require you to validate whether the widget behavior is the expected one.
 

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -70,7 +70,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
         getXAxis.setLabel("Time in sec")
         setTitle("Rock-Plot2d")
         
-        @preferences = Vizkit::Plot2D::Preferences.new('vizkit', 'plot2d', default_opts: @options)
+        @preferences = Vizkit::Plot2d::Preferences.new('vizkit', 'plot2d', default_opts: @options)
         @preferences.connect(SIGNAL('updated()')) do
             update_options
         end
@@ -216,7 +216,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
     end
 
     def open_preferences
-        @preferences_widget ||= Vizkit::Plot2D::PreferencesWidget.new(@preferences)
+        @preferences_widget ||= Vizkit::Plot2d::PreferencesWidget.new(@preferences)
         @preferences_widget.show()
     end
 

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -143,7 +143,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                 action = menu.exec(mapToGlobal(event.pos))
                 if(action == action_scrolling)
                     update_auto_scrolling !@options[:auto_scrolling]
-		elsif(action == action_clear)
+		        elsif(action == action_clear)
                     clearData()
                 elsif(action == action_reuse)
                     @options[:reuse] = !@options[:reuse]
@@ -161,6 +161,8 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                 elsif ((action == action_timestamp) || (action == action_sample_period))
                     @options[:plot_timestamps] =! @options[:plot_timestamps]
                 end
+                @preferences.load_from_hash(@options)
+                @preferences_widget.load if @preferences_widget
             end
         end
         

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -1,6 +1,25 @@
 #prepares the c++ qt widget for the use in ruby with widget_grid
 
 Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
+
+    class Plot2dEventFilter < ::Qt::Object
+        attr_accessor :preferences
+        
+        def initialize(preferences = nil)
+            super(nil)
+            @preferences = preferences
+        end
+
+        def eventFilter(obj,event)
+            if event.is_a?(Qt::CloseEvent)
+                if @preferences
+                    @preferences.close
+                end
+            end
+            return false
+        end
+    end
+
     attr_accessor :options
 
     def default_options()
@@ -216,7 +235,14 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
     end
 
     def open_preferences
-        @preferences_widget ||= Vizkit::Plot2d::PreferencesWidget.new(@preferences)
+        if !@preferences_widget
+            @preferences_widget = Vizkit::Plot2d::PreferencesWidget.new(@preferences)
+            if !@event_filter
+                installEventFilter(@event_filter = Plot2dEventFilter.new(@preferences_widget))
+            else
+                @event_filter.preferences = @preferences_widget
+            end
+        end
         @preferences_widget.show()
     end
 

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -79,6 +79,8 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                 action_scrolling.checkable = true
                 action_scrolling.checked = @options[:auto_scrolling]
                 menu.add_action(action_scrolling)
+                action_clear = Qt::Action.new("Clear", self)
+                menu.add_action(action_clear)
                 if @options[:multi_use_menu]
                     action_reuse = Qt::Action.new("Reuse Widget", self)
                     action_reuse.checkable = true
@@ -116,6 +118,8 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                 if(action == action_scrolling)
                     @options[:auto_scrolling] = !@options[:auto_scrolling]
                     update_zoom_range_flag(!@options[:auto_scrolling], @options[:use_y_axis2])
+                elsif(action == action_clear)
+                    clearData()
                 elsif(action == action_reuse)
                     @options[:reuse] = !@options[:reuse]
                 elsif(action == action_use_y2)

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -192,6 +192,11 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
         update_zoom_range_flag(!@options[:auto_scrolling], @options[:use_y_axis2])
     end
 
+    def update_timer(time_seconds = @options[:update_period])
+        @timer.stop
+        @timer.start(1000 * time_seconds)
+    end
+
     def update_options
         @options[:auto_scrolling]     = @preferences.autoscroll
         @options[:reuse]              = @preferences.reuse_widget
@@ -199,9 +204,11 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
         @options[:time_window]        = @preferences.time_window
         @options[:cached_time_window] = @preferences.time_window_cache
         @options[:pre_time_window]    = @options[:time_window] / 6
+        @options[:update_period]      = @preferences.update_period
 
         update_use_y2
         update_auto_scrolling
+        update_timer
     end
 
     def open_preferences

--- a/lib/vizkit/widgets/plot2d_preferences/preferences.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences.rb
@@ -1,5 +1,5 @@
 module Vizkit
-    module Plot2D
+    module Plot2d
         class Preferences < Qt::Object
             def initialize(name_org, name_app = "", parent: nil, default_opts: Hash.new)
                 super(parent)

--- a/lib/vizkit/widgets/plot2d_preferences/preferences.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences.rb
@@ -1,0 +1,136 @@
+module Vizkit
+    module Plot2D
+        class Preferences
+            def initialize(name_org, name_app = "")
+
+                @settings = Qt::Settings.new(name_org, name_app)
+
+                load
+            end
+
+            def load_bool(tag, default=false)
+                @settings.value(tag, Qt::Variant.new(default)).to_bool
+            end
+
+            def load_int(tag, default=0)
+                @settings.value(tag, Qt::Variant.new(default)).to_int
+            end
+
+            def load_list(tag, default=[0,1], &filter_cast)
+                list = @settings.value(tag, Qt::Variant.new(default)).to_list
+                filter_cast ||= ->(elem) {elem.to_int}
+                list.map &filter_cast
+            end
+
+            def save_value(tag, value)
+                @settings.set_value(tag, Qt::Variant.new(value))
+            end
+            
+            def save
+                @settings.begin_group('preferences')
+                begin
+                    @options_stash.each do |key,value|
+                        save_value(key, value)
+                    end
+                    @options = @options_stash.dup
+                ensure
+                    @settings.end_group
+                end
+            end
+
+            def load
+                @settings.begin_group('preferences')
+                begin
+                    @options = Hash[
+                        'auto_scroll'             => load_bool('auto_scroll'),
+                        'reuse'                   => load_bool('reuse'),
+                        '2yaxes'                  => load_bool('2yaxes'),
+                        'time_window/value'       => load_int('time_window/value'),
+                        'time_window_cache/value' => load_int('time_window_cache/value'),
+                        'time_window/range'       => load_list('time_window/range', [0.1, 300]),
+                        'time_window_cache/range' => load_list('time_window_cache/range', [0.1, 300]),
+                    ]
+                    @options_stash = @options.dup
+                ensure
+                    @settings.end_group
+                end
+            end
+
+            def hold=(value)
+                if [true, false].include? value
+                    @on_hold = value
+                else
+                    @on_hold = false
+                    stderr.puts '[Warning] Plot2D::Vizkit::Preferences.hold= received a nonboolean value and will default to false'
+                end
+            end
+
+            def on_hold?
+                @on_hold
+            end
+
+            def set_value(tag, value)
+                @options_stash[tag] = value
+                if !on_hold?
+                    @settings.begin_group('preferences')
+                    begin
+                        save_value(tag, value)
+                        @options[tag] = @options_stash[tag]
+                    ensure
+                        @settings.end_group
+                    end
+                end
+            end
+
+            def autoscroll
+                @options['auto_scroll']
+            end
+            
+            def autoscroll=(value)
+                set_value('auto_scroll', value)
+            end
+
+            def reuse_widget
+                @options['reuse']
+            end
+
+            def reuse_widget=(value)
+                set_value('reuse', value)
+            end
+
+            def use_2yaxes
+                @options['2yaxes']
+            end
+
+            def use_2yaxes=(value)
+                set_value('2yaxes', value)
+            end
+
+            def time_window
+                @options['time_window/value']
+            end
+
+            def time_window=(value)
+                set_value('time_window/value', value)
+            end
+
+            def time_window_cache
+                @options['time_window_cache/value']
+            end
+
+            def time_window_cache=(value)
+                set_value('time_window_cache/value', value)
+            end
+
+            def time_window_range
+                @options['time_window/range']
+            end
+
+            def time_window_cache_range
+                @options['time_window_cache/range']
+            end
+
+            private :load_bool, :load_int, :load_list, :save_value, :set_value
+        end
+    end
+end

--- a/lib/vizkit/widgets/plot2d_preferences/preferences.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences.rb
@@ -1,30 +1,61 @@
 module Vizkit
     module Plot2D
         class Preferences < Qt::Object
-            def initialize(name_org, name_app = "", parent: nil)
+            def initialize(name_org, name_app = "", parent: nil, default_opts: Hash.new)
                 super(parent)
-
+                
                 @settings = Qt::Settings.new(name_org, name_app, parent)
 
-                load
+                @options = Hash.new
+                @options_stash = Hash.new
+                keys = [:auto_scrolling, :time_window, :cached_time_window, :reuse,
+                        :use_y_axis2, :time_window_range, :cached_time_window_range];
+                keys.each do |key|
+                    value = default_opts[key]
+                    @options[key] = value
+                    @options_stash[key] = value
+                end
+                @options[:auto_scrolling]           ||= true
+                @options[:reuse]                    ||= true
+                @options[:use_y_axis2]              ||= false
+                @options[:time_window]              ||= 30
+                @options[:cached_time_window]       ||= 60
+                @options[:time_window_range]        ||= [1, 300]
+                @options[:cached_time_window_range] ||= [1, 300]
+                
+                @tags = Hash[
+                    :auto_scrolling           => 'auto_scrolling',
+                    :reuse                    => 'reuse_widget',
+                    :use_y_axis2              => 'use_y_axis2',
+                    :time_window              => 'time_window/value',
+                    :cached_time_window       => 'time_window_cache/value',
+                    :time_window_range        => 'time_window/range',
+                    :cached_time_window_range => 'time_window_cache/range'
+                ]
+
+                load(true)
             end
 
-            def load_bool(tag, default=false)
-                @settings.value(tag, Qt::Variant.new(default)).to_bool
+            def load_bool(key, default = @options[key])
+                load_value(key, default).to_bool
             end
 
-            def load_int(tag, default=0)
-                @settings.value(tag, Qt::Variant.new(default)).to_int
+            def load_int(key, default = @options[key])
+                load_value(key, default).to_int
             end
 
-            def load_list(tag, default=[0,1], &filter_cast)
-                list = @settings.value(tag, Qt::Variant.new(default)).to_list
+            def load_list(key, default = @options[key], &filter_cast)
+                list = load_value(key, default).to_list
                 filter_cast ||= ->(elem) {elem.to_int}
                 list.map &filter_cast
             end
 
-            def save_value(tag, value)
-                @settings.set_value(tag, Qt::Variant.new(value))
+            def load_value(key, default = @options[key])
+                @settings.value(@tags[key], Qt::Variant.new(default))
+            end
+
+            def save_value(key, value)
+                @settings.set_value(@tags[key], Qt::Variant.new(value))
             end
             
             def save
@@ -40,83 +71,87 @@ module Vizkit
                 end
             end
 
-            def load
+            def load(reset_stash = false)
                 @settings.begin_group('preferences')
                 begin
-                    @options = Hash[
-                        'auto_scroll'             => load_bool('auto_scroll', true),
-                        'reuse'                   => load_bool('reuse', true),
-                        '2yaxes'                  => load_bool('2yaxes', false),
-                        'time_window/value'       => load_int('time_window/value', 30),
-                        'time_window_cache/value' => load_int('time_window_cache/value', 60),
-                        'time_window/range'       => load_list('time_window/range', [1, 300]),
-                        'time_window_cache/range' => load_list('time_window_cache/range', [1, 300]),
-                    ]
-                    @options_stash = @options.dup
+                    @options[:auto_scrolling]           = load_bool(:auto_scrolling)
+                    @options[:reuse]                    = load_bool(:reuse)
+                    @options[:use_y_axis2]              = load_bool(:use_y_axis2)
+                    @options[:time_window]              = load_int(:time_window)
+                    @options[:cached_time_window]       = load_int(:cached_time_window)
+                    @options[:time_window_range]        = load_list(:time_window_range)
+                    @options[:cached_time_window_range] = load_list(:cached_time_window_range)
+                    if reset_stash
+                        @options_stash = @options.dup
+                    else
+                        @options_stash = @options_stash.map { |key,value|
+                            [ key , value ||= @options[key] ]
+                        }.to_h
+                    end
                 ensure
                     @settings.end_group
                 end
             end
 
-            def set_value(tag, value)
-                @options_stash[tag] = value
+            def set_value(key, value)
+                @options_stash[key.to_sym] = value
             end
 
-            def load_value(tag)
-                @options_stash[tag]
+            def get_value(key)
+                @options_stash[key]
             end
 
             def autoscroll
-                load_value('auto_scroll')
+                get_value(:auto_scrolling)
             end
             
             def autoscroll=(value)
-                set_value('auto_scroll', value)
+                set_value(:auto_scrolling, value)
             end
 
             def reuse_widget
-                load_value('reuse')
+                get_value(:reuse)
             end
 
             def reuse_widget=(value)
-                set_value('reuse', value)
+                set_value(:reuse, value)
             end
 
             def use_2yaxes
-                load_value('2yaxes')
+                get_value(:use_y_axis2)
             end
 
             def use_2yaxes=(value)
-                set_value('2yaxes', value)
+                set_value(:use_y_axis2, value)
             end
 
             def time_window
-                load_value('time_window/value')
+                get_value(:time_window)
             end
 
             def time_window=(value)
-                set_value('time_window/value', value)
+                set_value(:time_window, value)
             end
 
             def time_window_cache
-                load_value('time_window_cache/value')
+                get_value(:cached_time_window)
             end
 
             def time_window_cache=(value)
-                set_value('time_window_cache/value', value)
+                set_value(:cached_time_window, value)
             end
 
             def time_window_range
-                load_value('time_window/range')
+                get_value(:time_window_range)
             end
 
             def time_window_cache_range
-                load_value('time_window_cache/range')
+                get_value(:cached_time_window_range)
             end
 
             signals 'updated()'
 
-            private :load_bool, :load_int, :load_list, :save_value, :set_value
+            private :load_bool, :load_int, :load_list, :load_value, :save_value, :set_value, :get_value
         end
     end
 end

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -122,6 +122,7 @@ module Vizkit
                     @preferences.save
                 end
                 bt_load.connect(SIGNAL('clicked()')) do
+                    @preferences.load(true)
                     load
                 end
                 bt_apply.connect(SIGNAL('clicked()')) do
@@ -165,6 +166,7 @@ module Vizkit
             end
 
             def show
+                @preferences.load(false)
                 load
                 super
             end

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -61,6 +61,34 @@ module Vizkit
                 signals 'valueChanged(int)'
             end
 
+            class PreferencesItemSpinner
+                def initialize(name, parent = nil)
+                    @label = Qt::Label.new(name, parent)
+                    @spinner = Qt::DoubleSpinBox.new(parent)
+                    @spinner.decimals = 2
+                    @spinner.single_step = 0.01
+                end
+
+                def range=(minmax)
+                    @spinner.minimum = minmax[0]
+                    @spinner.maximum = minmax[1]
+                end
+
+                def value=(value)
+                    @spinner.value = value
+                end
+
+                def value
+                    @spinner.value
+                end
+
+                def add_to_grid(layout, row=0, col=0)
+                    layout.add_widget(@label,   row, col)
+                    layout.add_widget(@spinner, row, col + 1)
+                    row = row + 1
+                end
+            end
+
             def initialize(preferences = nil, parent = nil)
                 super(parent)
 
@@ -87,7 +115,8 @@ module Vizkit
 
                 @options_slider = Hash[
                     'time_window'       => PreferencesItemSlider.new('Time window', self),
-                    'time_window_cache' => PreferencesItemSlider.new('Time window cache', self)
+                    'time_window_cache' => PreferencesItemSlider.new('Time window cache', self),
+                    'update_period'     => PreferencesItemSpinner.new('Update period', self)
                 ]
 
                 row = 0
@@ -151,6 +180,7 @@ module Vizkit
                 @preferences.use_2yaxes        = @options_cb['2yaxes'].selected
                 @preferences.time_window       = @options_slider['time_window'].value
                 @preferences.time_window_cache = @options_slider['time_window_cache'].value
+                @preferences.update_period     = @options_slider['update_period'].value
 
                 emit @preferences.updated()
             end
@@ -161,8 +191,10 @@ module Vizkit
                 @options_cb['2yaxes'].selected             = @preferences.use_2yaxes
                 @options_slider['time_window'].range       = @preferences.time_window_range
                 @options_slider['time_window_cache'].range = @preferences.time_window_cache_range
+                @options_slider['update_period'].range     = @preferences.update_period_range
                 @options_slider['time_window'].value       = @preferences.time_window
                 @options_slider['time_window_cache'].value = @preferences.time_window_cache
+                @options_slider['update_period'].value     = @preferences.update_period
             end
 
             def show

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -1,5 +1,5 @@
 module Vizkit
-    module Plot2D
+    module Plot2d
         class PreferencesWidget < Qt::Widget
             class PreferencesItemCB
                 def initialize(name, parent = nil)
@@ -95,14 +95,14 @@ module Vizkit
                 if preferences
                     @preferences = preferences
                 else
-                    @preferences = Vizkit::Plot2D::Preferences.new('vizkit', 'plot2d')
+                    @preferences = Vizkit::Plot2d::Preferences.new('vizkit', 'plot2d')
                 end
 
                 create_ui
             end
 
             def create_ui
-                set_window_title('Plot2D Preferences')
+                set_window_title('Plot2d Preferences')
 
                 layout_main = Qt::VBoxLayout.new(self)
                 layout_main.add_layout( layout_content = Qt::GridLayout.new )

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -109,10 +109,21 @@ module Vizkit
                 layout_content.add_item( Qt::SpacerItem.new(1, 10) )
 
                 layout_buttons = Qt::HBoxLayout.new
+                layout_buttons.add_widget( bt_save = Qt::PushButton.new('Save', self) )
+                layout_buttons.add_widget( bt_load = Qt::PushButton.new('Load', self) )
+                layout_buttons.add_stretch
+                layout_buttons.add_spacing(20)
                 layout_buttons.add_stretch
                 layout_buttons.add_widget( bt_apply = Qt::PushButton.new('Apply', self) )
                 layout_buttons.add_widget( bt_ok = Qt::PushButton.new('Ok', self) )
                 layout_buttons.add_widget( bt_cancel = Qt::PushButton.new('Cancel', self) )
+                bt_save.connect(SIGNAL('clicked()')) do
+                    apply
+                    @preferences.save
+                end
+                bt_load.connect(SIGNAL('clicked()')) do
+                    load
+                end
                 bt_apply.connect(SIGNAL('clicked()')) do
                     apply
                 end
@@ -123,22 +134,24 @@ module Vizkit
                 bt_cancel.connect(SIGNAL('clicked()')) do
                     close
                 end
+                bt_save.toolTip   = 'Saves the settings for all future plot2d instances'
+                bt_apply.toolTip  = 'Applies the settings to the current plot2d instance'
+                bt_ok.toolTip     = 'Applies the settings and exit'
+                bt_cancel.toolTip = 'Exits without saving or applying changes'
+                layout_main.add_stretch
+                layout_main.add_spacing(10)
                 layout_main.add_stretch
                 layout_main.add_layout(layout_buttons, row)
             end
 
             def apply
-                @preferences.hold = true
-                begin
-                    @preferences.autoscroll        = @options_cb['auto_scroll'].selected
-                    @preferences.reuse_widget      = @options_cb['reuse'].selected
-                    @preferences.use_2yaxes        = @options_cb['2yaxes'].selected
-                    @preferences.time_window       = @options_slider['time_window'].value
-                    @preferences.time_window_cache = @options_slider['time_window_cache'].value
-                    @preferences.save
-                ensure
-                    @preferences.hold = false
-                end
+                @preferences.autoscroll        = @options_cb['auto_scroll'].selected
+                @preferences.reuse_widget      = @options_cb['reuse'].selected
+                @preferences.use_2yaxes        = @options_cb['2yaxes'].selected
+                @preferences.time_window       = @options_slider['time_window'].value
+                @preferences.time_window_cache = @options_slider['time_window_cache'].value
+
+                emit @preferences.updated()
             end
 
             def load

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -1,0 +1,160 @@
+module Vizkit
+    module Plot2D
+        class PreferencesWidget < Qt::Widget
+            class PreferencesItemCB
+                def initialize(name, parent = nil)
+                    @label = Qt::Label.new(name, parent)
+                    @checkbox = Qt::CheckBox.new(parent)
+                end
+
+                def selected=(value)
+                    @checkbox.checked = value
+                end
+
+                def selected
+                    @checkbox.checked
+                end
+
+                def add_to_grid(layout, row=0, col=0)
+                    layout.add_widget(@label,    row, col)
+                    layout.add_widget(@checkbox, row, col + 1)
+                    row = row + 1
+                end
+            end
+
+            class PreferencesItemSlider < Qt::Object
+                def initialize(name, parent = nil)
+                    super(parent)
+                    @label = Qt::Label.new(name, parent)
+                    @slider = Qt::Slider.new(Qt::Horizontal, parent)
+                    @spinner = Qt::SpinBox.new(parent)
+
+                    @slider.set_minimum_width(180)
+
+                    Qt::Object.connect(@slider,  SIGNAL('valueChanged(int)'), @spinner, SLOT('setValue(int)'))
+                    Qt::Object.connect(@spinner, SIGNAL('valueChanged(int)'), @slider,  SLOT('setValue(int)'))
+                    Qt::Object.connect(@slider,  SIGNAL('valueChanged(int)'), self, SIGNAL('valueChanged(int)'))
+                end
+
+                def range=(minmax)
+                    @slider.minimum  = minmax[0]
+                    @slider.maximum  = minmax[1]
+                    @spinner.minimum = minmax[0]
+                    @spinner.maximum = minmax[1]
+                end
+
+                def value=(value)
+                    @slider.value = value
+                end
+
+                def value
+                    @slider.value
+                end
+
+                def add_to_grid(layout, row=0, col=0)
+                    layout.add_widget(@label,   row, col)
+                    layout.add_widget(@slider,  row, col + 1, 1, 2)
+                    layout.add_widget(@spinner, row, col + 3)
+                    row = row + 1
+                end
+
+                signals 'valueChanged(int)'
+            end
+
+            def initialize(preferences = nil, parent = nil)
+                super(parent)
+
+                if preferences
+                    @preferences = preferences
+                else
+                    @preferences = Vizkit::Plot2D::Preferences.new('vizkit', 'plot2d')
+                end
+
+                create_ui
+            end
+
+            def create_ui
+                set_window_title('Plot2D Preferences')
+
+                layout_main = Qt::VBoxLayout.new(self)
+                layout_main.add_layout( layout_content = Qt::GridLayout.new )
+
+                @options_cb = Hash[
+                    'auto_scroll' => PreferencesItemCB.new('Autoscroll', self),
+                    'reuse'       => PreferencesItemCB.new('Reuse widget', self),
+                    '2yaxes'      => PreferencesItemCB.new('Use 2 y-axes', self),
+                ]
+
+                @options_slider = Hash[
+                    'time_window'       => PreferencesItemSlider.new('Time window', self),
+                    'time_window_cache' => PreferencesItemSlider.new('Time window cache', self)
+                ]
+
+                row = 0
+                items = @options_cb.merge(@options_slider)
+                items.each do |_,item|
+                    row += item.add_to_grid(layout_content, row, 0)
+                end
+                @options_slider['time_window'].connect(SIGNAL('valueChanged(int)')) do |value|
+                    if (value > @options_slider['time_window_cache'].value)
+                        @options_slider['time_window_cache'].value = value
+                    end
+                end
+                @options_slider['time_window_cache'].connect(SIGNAL('valueChanged(int)')) do |value|
+                    if (value < @options_slider['time_window'].value)
+                        @options_slider['time_window'].value = value
+                    end
+                end
+
+                layout_content.add_item( Qt::SpacerItem.new(1, 10) )
+
+                layout_buttons = Qt::HBoxLayout.new
+                layout_buttons.add_stretch
+                layout_buttons.add_widget( bt_apply = Qt::PushButton.new('Apply', self) )
+                layout_buttons.add_widget( bt_ok = Qt::PushButton.new('Ok', self) )
+                layout_buttons.add_widget( bt_cancel = Qt::PushButton.new('Cancel', self) )
+                bt_apply.connect(SIGNAL('clicked()')) do
+                    apply
+                end
+                bt_ok.connect(SIGNAL('clicked()')) do
+                    apply
+                    close
+                end
+                bt_cancel.connect(SIGNAL('clicked()')) do
+                    close
+                end
+                layout_main.add_stretch
+                layout_main.add_layout(layout_buttons, row)
+            end
+
+            def apply
+                @preferences.hold = true
+                begin
+                    @preferences.autoscroll        = @options_cb['auto_scroll'].selected
+                    @preferences.reuse_widget      = @options_cb['reuse'].selected
+                    @preferences.use_2yaxes        = @options_cb['2yaxes'].selected
+                    @preferences.time_window       = @options_slider['time_window'].value
+                    @preferences.time_window_cache = @options_slider['time_window_cache'].value
+                    @preferences.save
+                ensure
+                    @preferences.hold = false
+                end
+            end
+
+            def load
+                @options_cb['auto_scroll'].selected        = @preferences.autoscroll
+                @options_cb['reuse'].selected              = @preferences.reuse_widget
+                @options_cb['2yaxes'].selected             = @preferences.use_2yaxes
+                @options_slider['time_window'].range       = @preferences.time_window_range
+                @options_slider['time_window_cache'].range = @preferences.time_window_cache_range
+                @options_slider['time_window'].value       = @preferences.time_window
+                @options_slider['time_window_cache'].value = @preferences.time_window_cache
+            end
+
+            def show
+                load
+                super
+            end
+        end
+    end
+end

--- a/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
+++ b/lib/vizkit/widgets/plot2d_preferences/preferences_widget.rb
@@ -151,7 +151,7 @@ module Vizkit
                     @preferences.save
                 end
                 bt_load.connect(SIGNAL('clicked()')) do
-                    @preferences.load(true)
+                    @preferences.load
                     load
                 end
                 bt_apply.connect(SIGNAL('clicked()')) do
@@ -198,7 +198,6 @@ module Vizkit
             end
 
             def show
-                @preferences.load(false)
                 load
                 super
             end

--- a/test/widgets/helpers.rb
+++ b/test/widgets/helpers.rb
@@ -1,0 +1,82 @@
+require 'vizkit'
+require 'minitest/spec'
+require 'minitest/autorun'
+
+module Vizkit
+    module TestHelpers
+        def setup
+            super
+            @timers = []
+            @widgets = []
+            Orocos.load unless Orocos.loaded?
+
+            @confirmation_dialog = Qt::Widget.new
+            layout = Qt::VBoxLayout.new(@confirmation_dialog)
+            @text_field = Qt::Label.new
+            layout.add_widget @text_field
+            button_layout = Qt::HBoxLayout.new
+            layout.add_layout button_layout
+            button_layout.add_widget(@yes_btn = Qt::PushButton.new("Yes"))
+            button_layout.add_widget(@no_btn = Qt::PushButton.new("No"))
+            @yes_btn.connect(SIGNAL('clicked()')) do
+                @confirm_result = true
+            end
+            @no_btn.connect(SIGNAL('clicked()')) do
+                @confirm_result = false
+            end
+        end
+
+        def teardown
+            @confirmation_dialog.hide
+            @timers.each(&:stop)
+            @widgets.each(&:close)
+            super
+        end
+
+        def timer(period)
+            timer = Qt::Timer.new
+            timer.connect(SIGNAL('timeout()')) do
+                yield
+            end
+            timer.start(period)
+            register_timer(timer)
+        end
+
+        def register_timer(timer)
+            @timers << timer
+        end
+
+        def register_widget(widget)
+            @widgets << widget
+        end
+
+        def run_confirmation_dialog(text, no_btn_visible: true)
+            @text_field.text = text
+            @confirm_result = nil
+            if no_btn_visible
+                @no_btn.show
+            else
+                @no_btn.hide
+            end
+
+            @confirmation_dialog.show
+            while @confirm_result.nil?
+                Vizkit.step
+                sleep 0.01
+            end
+            @confirm_result
+        ensure
+            @confirmation_dialog.hide
+        end
+
+        def step(text)
+            run_confirmation_dialog(text, no_btn_visible: false)
+        end
+
+        def confirm(text)
+            valid = run_confirmation_dialog(text, no_btn_visible: true)
+            assert valid, "#{text} was not confirmed by the user"
+        end
+    end
+end
+

--- a/test/widgets/test_plot2d.rb
+++ b/test/widgets/test_plot2d.rb
@@ -1,0 +1,56 @@
+require_relative 'helpers'
+
+module Vizkit
+    describe 'Plot2d' do
+        include TestHelpers
+
+        before do
+            register_widget(@plot2d = Vizkit.default_loader.Plot2d)
+            @plot2d.show
+        end
+
+        it "clears when the 'Clear' context entry is chosen" do
+            last_value = 0
+            timer 100 do
+                @plot2d.update(last_value += rand - 0.5, 'test')
+            end
+            confirm 'A curve should appear, click the "Clear" '\
+              'button and make sure it disappears before reappearing again'
+        end
+
+        it "starts a new plotting widget if 'Reuse Widget' is unchecked" do
+            last_value = 0
+            timer 100 do
+                @plot2d.update(last_value += rand - 0.5, 'test')
+            end
+            step 'disable "Reuse Widget" and click Yes to continue'
+            register_widget(@plot2d = Vizkit.default_loader.Plot2d)
+            @plot2d.show
+            confirm 'a new plot should have appeared, and the data is now updated in the new plot'
+        end
+
+        it "uses the other Y axis if 'Use 2. Y-Axis' is enabled" do
+            last_value = 0
+            timer 100 do
+                @plot2d.update(last_value += rand - 0.5, 'test')
+            end
+            step 'enable "Use 2. Y-Axis" and click Yes to continue'
+
+            value2 = 0
+            timer 100 do
+                @plot2d.update(value2 += (rand - 0.5) * 100, 'test*100')
+            end
+            confirm 'the new plot, that has a widely different scale than the first one, '\
+                'should be using the second axis'
+            step 'now disable "Use 2. Y-Axis" and click Yes to continue'
+
+            value3 = 0
+            timer 100 do
+                @plot2d.update(value3 += (rand - 0.5), 'test3')
+            end
+            confirm 'this third plot, should be using the first axis again. '\
+                'It has the same scale than the first plot'
+        end
+    end
+end
+

--- a/test/widgets/test_plot2d_preferences.rb
+++ b/test/widgets/test_plot2d_preferences.rb
@@ -1,0 +1,71 @@
+require_relative 'helpers'
+
+module Vizkit
+    describe 'Plot2d' do
+        include TestHelpers
+
+        before do
+            register_widget(@plot2d = Vizkit.default_loader.Plot2d)
+            @plot2d.show
+        end
+
+        it "changes the update period" do
+            last_value = 0
+            timer 20 do
+                @plot2d.update(last_value += rand - 0.5, 'test')
+            end
+            step 'Set the update period to 1 second and click "Apply", you should clearly '\
+                'see the curve updating every second'
+            confirm 'Now change the update period to 0.02 seconds and "Apply", the curve'\
+                'should update smoothly now'
+        end
+
+        it "changes the time window" do
+            confirm 'Verify that you can\'t set the "time window" bigger than the "time window cache"'
+            
+            freq = 2 * Math::PI / 2
+            t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            timer 40 do |time|
+                time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+                @plot2d.update(2 * Math::sin(freq * time), 'test')
+            end
+            confirm 'Set the "time window" to 30 seconds and click "Apply", you should see several '\
+                "periods of the sine wave"
+            confirm 'Now change the "time window" to 4 seconds, you should see two whole periods '\
+                'of the sine wave'
+            confirm "Change the \"time window cache\" to 10 seconds and click \"Apply\", you should be "\
+                "able to remove\n\"auto-scroll\" and zoom out to see that only the last 10 seconds of data "\
+                "is recorder"
+        end
+
+        it "change settings locally and permanently" do
+            freq = [2 * Math::PI / 2 , 2 * Math::PI * 1.5 , 2 * Math::PI * 3]
+            t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            timer 40 do |time|
+                time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - t0
+                value = 0
+                freq.each do |f|
+                    value += Math.sin(f * time)
+                end
+                @plot2d.update(value, 'test')
+                @plot2d_other.update(value, 'test') if @plot2d_other
+            end
+            confirm 'Play around with the settings and verify that the "Apply", "Ok" and "Cancel" '\
+                'buttons work as expected.'
+            step 'Choose some settings of your liking, disable "Reuse widget" and click "Save" '\
+                'to continue.'
+            register_widget(@plot2d_other = Vizkit.default_loader.Plot2d)
+            @plot2d_other.show
+            confirm 'A new plot should have appeared with settings matching the ones you saved. '\
+                'You can open "Preferences" for this new plot and check this out.'
+            confirm 'Play around with the settings on both plots and verify that they are '\
+                'independent of each other as long as you don\'t save them'
+        end
+
+        it "closes preferences when plot closes" do
+            step 'Open the "Preferences" window to continue'
+            confirm 'Close the plot, the "Preferences" window should have closed as well'
+        end
+    end
+end
+


### PR DESCRIPTION
Through this window one may alter the settings shown below
![preferences](https://user-images.githubusercontent.com/5129986/53851867-cbe9f180-3f9e-11e9-851d-14af57851796.png)
The window is opened by right-clicking the plot area and selecting "Preferences".

Each Plot2d instance has its own preferences window. Global settings are loaded when the plot is created and might be reloaded by clicking "Load" or overwritten by clicking "Save". The buttons "Apply" and "Ok" only change the current instance settings.