### PR TITLE
feat: allow to optionally disable the global shortcut event filter

### DIFF
--- a/lib/vizkit/vizkit.rb
+++ b/lib/vizkit/vizkit.rb
@@ -132,10 +132,12 @@ module Vizkit
             return false
         end
     end
-    def self.exec(async_period: 0.01)
-        #install event filter
-        obj = ShortCutFilter.new
-        $qApp.installEventFilter(obj)
+    def self.exec(async_period: 0.01, global_shortcuts: true)
+        if global_shortcuts
+            #install event filter
+            obj = ShortCutFilter.new
+            $qApp.installEventFilter(obj)
+        end
 
         timer = Qt::Timer.new
         timer.connect SIGNAL("timeout()") do


### PR DESCRIPTION
It consumes a lot of CPU for little functionality. The same functionality would be discoverable and zero-cost by adding a button on the UI