### PR TITLE
fix: improve handling of mismatched types (on top of #7)

### DIFF
--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -638,6 +638,15 @@ module Vizkit
                     update port.new_sample.zero!
                     @sent_sample = port.new_sample.zero!
                     setEditable @options[:editable] if @options[:item_type] != :label
+                rescue ArgumentError => e
+                    if e.message =~ /null type/
+                        setForeground(ErrorBrush)
+                        if @options[:item_type] != :label
+                            @options[:text] = "Mismatching type definition for #{port.type.name}"
+                        end
+                    else
+                        raise
+                    end
                 rescue Orocos::TypekitTypeNotFound
                     setForeground(ErrorBrush)
                     if @options[:item_type] != :label


### PR DESCRIPTION
On top of #7 

If the remote and local types have different definitions, it will end up showing up as a "null" type. Handle the error and present a usable error message to the user.