### PR TITLE
fix: output port display in tree view

### DIFF
--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -543,6 +543,13 @@ module Vizkit
                 p2.expand
             end
         end
+
+        def expand(propagated = false)
+            @expanded = true
+            each_child do |item|
+                item.expand(propagated)
+            end
+        end
     end
 
     class InputPortsItem < PortsItem


### PR DESCRIPTION
3d48298443c70be3b69ec23e854609e6801c4f26 unintentinally removed the `expanded` method from OutputPortsItem, which breaks output port display